### PR TITLE
Fix duplicated Windows:API::DATA_TYPES key

### DIFF
--- a/lib/windows/api.rb
+++ b/lib/windows/api.rb
@@ -53,7 +53,6 @@ module Windows
       'HCONV'        => 'L',
       'HDC'          => 'L',
       'HFILE'        => 'I',
-      'HKEY'         => 'L',
       'HFONT'        => 'L',
       'HINSTANCE'    => 'L',
       'HKEY'         => 'L',


### PR DESCRIPTION
Fix  #3: Ruby 2.2 warning about this duplicated KEY :
`windows-api-0.4.2/lib/windows/api.rb:56: warning: duplicated key at line 59 ignored: "HKEY"`
