### PR TITLE
Support Ruby 3.1 UCRT binary

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
         os:
           - windows-latest
         experimental: [false]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ test_script:
 
 environment:
   matrix:
+    - ruby_version: "31-x64"
+    - ruby_version: "31"
     - ruby_version: "30-x64"
     - ruby_version: "30"
     - ruby_version: "27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ test_script:
 environment:
   matrix:
     - ruby_version: "31-x64"
-    - ruby_version: "31"
     - ruby_version: "30-x64"
     - ruby_version: "30"
     - ruby_version: "27-x64"
@@ -34,3 +33,15 @@ environment:
     - ruby_version: "21"
     - ruby_version: "200-x64"
     - ruby_version: "200"
+
+for:
+-
+  matrix:
+    only:
+      - ruby_version: "31-x64"
+  install:
+    - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+    - ruby --version
+    - gem --version
+    - ridk install 1 3
+    - ridk exec bundle install

--- a/lib/windows/api.rb
+++ b/lib/windows/api.rb
@@ -8,7 +8,9 @@ module Windows
 
   # With Microsoft Visual C++ 8 and later users should use the associated
   # DLL instead of msvcrt directly, if possible.
-  if CONFIG['host_os'].split('_')[1]
+  if RUBY_PLATFORM.split('-')[-1] == "ucrt"
+    MSVCRT_DLL = 'ucrtbase'
+  elsif CONFIG['host_os'].split('_')[1]
     if CONFIG['host_os'].split('_')[1].to_i >= 80
       MSVCRT_DLL = 'msvcr' + CONFIG['host_os'].split('_')[1]
     else

--- a/test/test_windows_api.rb
+++ b/test/test_windows_api.rb
@@ -53,7 +53,7 @@ class TC_Windows_API < Test::Unit::TestCase
 
   def setup
     @buf = 0.chr * 256
-    @runtimes = ['msvcrt', 'msvcr80', 'msvcr90', 'msvcr100']
+    @runtimes = ['msvcrt', 'msvcr80', 'msvcr90', 'msvcr100', 'ucrtbase']
   end
 
   def test_version


### PR DESCRIPTION
RubyInstaller has migrate from msvcrt.dll to ucrt.dll:
https://rubyinstaller.org/2021/12/31/rubyinstaller-3.1.0-1-released.html

So that symbols should be loaded from later one.
Althouth I considered introducing a new constant like `UCRT_DLL`, this
commit still using `MSVCRT_DLL` even if Ruby is run on ucrt.dll to keep
backward compatibility. I think replacing `MSVCRT_DLL` with `UCRT_DLL`
is almost meaningless, they won't used at same time.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>